### PR TITLE
fix(footer): open social links in new tab and add security rel

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,18 +217,39 @@
   </main>
 
   <footer class="site-footer">
-    <div class="container site-footer__inner">
-      <section class="wrapper site-footer__platform">
-        <a href="https://www.facebook.com/thetitanmethod"><img class="icon" src="images/facebook.png" alt="facebook" /></a>
-        <a href="https://www.instagram.com/thetitanmethod"><img class="icon" src="images/instagram.png" alt="instagram" /></a>
-        <a href="https://www.youtube.com/@thetitanmethod"><img class="icon" src="images/youtube.png" alt="youtube" /></a>
-        <a href="https://www.tiktok.com/@thetitanmethod"><img class="icon" src="images/tiktok.png" alt="tiktok" /></a>
-      </section>
-      <section class="wrapper site-footer__legal">
-        <p>&copy; 2025 The Titan Method. All Rights Reserved. Link to Privacy Policy and Terms of Service.</p>
-      </section>
-    </div>
-  </footer>
+  <div class="container site-footer__inner">
+    <section class="wrapper site-footer__platform">
+      <a href="https://www.facebook.com/thetitanmethod"
+         class="social-link"
+         target="_blank" rel="noopener noreferrer"
+         aria-label="The Titan Method on Facebook">
+        <img class="icon" src="images/facebook.png" alt="facebook" />
+      </a>
+      <a href="https://www.instagram.com/thetitanmethod"
+         class="social-link"
+         target="_blank" rel="noopener noreferrer"
+         aria-label="The Titan Method on Instagram">
+        <img class="icon" src="images/instagram.png" alt="instagram" />
+      </a>
+      <a href="https://www.youtube.com/@thetitanmethod"
+         class="social-link"
+         target="_blank" rel="noopener noreferrer"
+         aria-label="The Titan Method on YouTube">
+        <img class="icon" src="images/youtube.png" alt="youtube" />
+      </a>
+      <a href="https://www.tiktok.com/@thetitanmethod"
+         class="social-link"
+         target="_blank" rel="noopener noreferrer"
+         aria-label="The Titan Method on TikTok">
+        <img class="icon" src="images/tiktok.png" alt="tiktok" />
+      </a>
+    </section>
+    <section class="wrapper site-footer__legal">
+      <p>&copy; 2025 The Titan Method. All Rights Reserved. Link to Privacy Policy and Terms of Service.</p>
+    </section>
+  </div>
+</footer>
+
 
   <!-- Bootstrap 5 JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
- Added target="_blank" and rel="noopener noreferrer" to footer social links
- Preserved internal navigation (no new tabs for local links)
- Added aria-labels for icon-only anchors to improve a11y

Verification:
- Desktop (Chrome): links open in a new tab; landing page remains open
- Mobile (iOS Safari / Android Chrome): links open in a new tab; page state preserved
- DevTools check confirms attributes present on all external footer links